### PR TITLE
Added additional campaign utm params that GA will accept.

### DIFF
--- a/lib/universal/mapper.js
+++ b/lib/universal/mapper.js
@@ -599,6 +599,8 @@ function createCommonGAForm(facade, settings) {
   if (campaign.source) form.cs = campaign.source;
   if (campaign.medium) form.cm = campaign.medium;
   if (campaign.content) form.cc = campaign.content;
+  if (campaign.term) form.ck = campaign.term;
+  if (campaign.id) form.ci = campaign.id;
 
   // screen
   if (screen.height && screen.width) {

--- a/test/fixtures/page-campaign.json
+++ b/test/fixtures/page-campaign.json
@@ -13,7 +13,8 @@
         "source": "c-source",
         "medium": "c-medium",
         "term": "c-term",
-        "content": "c-content"
+        "content": "c-content",
+        "id": "c-id"
       }
     }
   },
@@ -28,6 +29,8 @@
     "cs": "c-source",
     "cm": "c-medium",
     "cc": "c-content",
-    "v": 1
+    "v": 1,
+    "ck": "c-term",
+    "ci": "c-id"
   }
 }


### PR DESCRIPTION
There are two additional campaign parameters that customers can pass. `context.campaign.term` is the same as `campaign keyword` (`ck`). `context.campaign.id` is not a specced utm parameter, however, it is something that Google Analytics accepts as [seen here](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#campaignKeyword), so I figure we might as well add it.   