### PR TITLE
update/ecommerce-spec-v2

### DIFF
--- a/lib/universal/enhanced-ecommerce.js
+++ b/lib/universal/enhanced-ecommerce.js
@@ -7,127 +7,127 @@
 var mapper = require('./mapper');
 
 /**
- * Viewed Product. (Enhanced ecommerce.)
+ * Product Viewed. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.viewedProduct = function(track, done) {
+exports.productViewed = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.viewedProduct(track, this.settings))
+    .send(mapper.productViewed(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Clicked Product. (Enhanced ecommerce.)
+ * Product Clicked. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.clickedProduct = function(track, done) {
+exports.productClicked = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.clickedProduct(track, this.settings))
+    .send(mapper.productClicked(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Added Product. (Enhanced ecommerce.)
+ * Product Added (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.addedProduct = function(track, done) {
+exports.productAdded = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.addedProduct(track, this.settings))
+    .send(mapper.productAdded(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Removed Product. (Enhanced ecommerce.)
+ * Product Removed. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.removedProduct = function(track, done) {
+exports.productRemoved = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.removedProduct(track, this.settings))
+    .send(mapper.productRemoved(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Started Order. (Enhanced ecommerce.)
+ * Order Started. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.startedOrder = function(track, done) {
+exports.orderStarted = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.startedOrder(track, this.settings))
+    .send(mapper.orderStarted(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Updated Order. (Enhanced ecommerce.)
+ * Order Updated. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.updatedOrder = function(track, done) {
+exports.orderUpdated = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.updatedOrder(track, this.settings))
+    .send(mapper.orderUpdated(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Viewed Checkout Step. (Enhanced ecommerce.)
+ * Checkout Step Viewed. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.viewedCheckoutStep = function(track, done) {
+exports.checkoutStepViewed = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.viewedCheckoutStep(track, this.settings))
+    .send(mapper.checkoutStepViewed(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Completed Checkout Step. (Enhanced ecommerce.)
+ * Checkout Step Completed. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.completedCheckoutStep = function(track, done) {
+exports.checkoutStepCompleted = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.completedCheckoutStep(track, this.settings))
+    .send(mapper.checkoutStepCompleted(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#ecom
  *
@@ -143,55 +143,55 @@ exports.completedCheckoutStep = function(track, done) {
  * @param {Function} callback
  */
 
-exports.completedOrder = function(track, done) {
+exports.orderCompleted = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.completedOrderEnhanced(track, this.settings))
+    .send(mapper.orderCompletedEnhanced(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Refunded Order. (Enhanced ecommerce.)
+ * Order Refunded. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.refundedOrder = function(track, done) {
+exports.orderRefunded = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.refundedOrder(track, this.settings))
+    .send(mapper.orderRefunded(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Viewed Promotion. (Enhanced ecommerce.)
+ * Promotion Viewed. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.viewedPromotion = function(track, done) {
+exports.promotionViewed = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.viewedPromotion(track, this.settings))
+    .send(mapper.promotionViewed(track, this.settings))
     .end(this.handle(done));
 };
 
 /**
- * Clicked Promotion. (Enhanced ecommerce.)
+ * Promotion Clicked. (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.clickedPromotion = function(track, done) {
+exports.promotionClicked = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.clickedPromotion(track, this.settings))
+    .send(mapper.promotionClicked(track, this.settings))
     .end(this.handle(done));
 };

--- a/lib/universal/mapper.js
+++ b/lib/universal/mapper.js
@@ -79,7 +79,7 @@ exports.track = function(track, settings) {
 };
 
 /**
- * Map Standard Completed Order.
+ * Map Standard Order Completed.
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#ecom
  *
@@ -97,7 +97,7 @@ exports.track = function(track, settings) {
  * @return {Object[]}
  */
 
-exports.completedOrder = function(track, settings) {
+exports.orderCompleted = function(track, settings) {
   var currency = track.currency();
   var orderId = track.orderId();
   var products = track.products();
@@ -134,10 +134,10 @@ exports.completedOrder = function(track, settings) {
 };
 
 /**
- * Map Viewed Product (Enhanced).
+ * Map Product Viewed (Enhanced).
  */
 
-exports.viewedProduct = function(track, settings) {
+exports.productViewed = function(track, settings) {
   return extend(
     formatEnhancedEcommerceEvent(track, 'detail'),
     createCommonGAForm(track, settings),
@@ -147,7 +147,7 @@ exports.viewedProduct = function(track, settings) {
 };
 
 /**
- * Map Clicked Product (Enhanced).
+ * Map Product Clicked (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -167,7 +167,7 @@ exports.viewedProduct = function(track, settings) {
  *    - v
  */
 
-exports.clickedProduct = function(track, settings) {
+exports.productClicked = function(track, settings) {
   return extend(
     formatEnhancedEcommerceEvent(track, 'click'),
     createCommonGAForm(track, settings),
@@ -177,7 +177,7 @@ exports.clickedProduct = function(track, settings) {
 };
 
 /**
- * Map Added Product (Enhanced).
+ * Map Product Added (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -201,7 +201,7 @@ exports.clickedProduct = function(track, settings) {
  * @return {Object}
  */
 
-exports.addedProduct = function(track, settings) {
+exports.productAdded = function(track, settings) {
   return extend(
     formatEnhancedEcommerceEvent(track, 'add'),
     createCommonGAForm(track, settings),
@@ -211,7 +211,7 @@ exports.addedProduct = function(track, settings) {
 };
 
 /**
- * Map Removed Product (Enhanced).
+ * Map Product Removed (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -235,7 +235,7 @@ exports.addedProduct = function(track, settings) {
  * @return {Object}
  */
 
-exports.removedProduct = function(track, settings) {
+exports.productRemoved = function(track, settings) {
   return extend(
     formatEnhancedEcommerceEvent(track, 'remove'),
     createCommonGAForm(track, settings),
@@ -245,7 +245,7 @@ exports.removedProduct = function(track, settings) {
 };
 
 /**
- * Map Started Order (Enhanced).
+ * Map Order Started (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -263,12 +263,12 @@ exports.removedProduct = function(track, settings) {
  * @return {Object}
  */
 
-exports.startedOrder = function(track, settings) {
-  return exports.viewedCheckoutStep(track, settings);
+exports.orderStarted = function(track, settings) {
+  return exports.checkoutStepViewed(track, settings);
 };
 
 /**
- * Map Updated Order (Enhanced).
+ * Map Order updated (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#checkout-steps
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
@@ -290,12 +290,12 @@ exports.startedOrder = function(track, settings) {
  * @return {Object}
  */
 
-exports.updatedOrder = function(track, settings) {
-  return exports.viewedCheckoutStep(track, settings);
+exports.orderUpdated = function(track, settings) {
+  return exports.checkoutStepViewed(track, settings);
 };
 
 /**
- * Map Completed Checkout Step (Enhanced).
+ * Map Checkout Step Completed (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -320,7 +320,7 @@ exports.updatedOrder = function(track, settings) {
  * @return {Object}
  */
 
-exports.completedCheckoutStep = function(track, settings) {
+exports.checkoutStepCompleted = function(track, settings) {
   var renames = {
     option: 'col',
     step: 'cos'
@@ -334,7 +334,7 @@ exports.completedCheckoutStep = function(track, settings) {
 };
 
 /**
- * Map Viewed Checkout Step (Enhanced).
+ * Map Checkout Step Viewed (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -368,7 +368,7 @@ exports.completedCheckoutStep = function(track, settings) {
  * @return {Object}
  */
 
-exports.viewedCheckoutStep = function(track, settings) {
+exports.checkoutStepViewed = function(track, settings) {
   var renames = {
     step: 'cos',
     option: 'col'
@@ -384,7 +384,7 @@ exports.viewedCheckoutStep = function(track, settings) {
 };
 
 /**
- * Map Completed Order (Enhanced).
+ * Map Order Completed (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -421,7 +421,7 @@ exports.viewedCheckoutStep = function(track, settings) {
  * @return {Object}
  */
 
-exports.completedOrderEnhanced = function(track, settings) {
+exports.orderCompletedEnhanced = function(track, settings) {
   return compactObject(extend(
     {
       ta: track.proxy('properties.affiliation'),
@@ -439,7 +439,7 @@ exports.completedOrderEnhanced = function(track, settings) {
 };
 
 /**
- * Map Refunded Order (Enhanced).
+ * Map Order Refunded (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
@@ -461,7 +461,7 @@ exports.completedOrderEnhanced = function(track, settings) {
  * @return {Object}
  */
 
-exports.refundedOrder = function(track, settings) {
+exports.orderRefunded = function(track, settings) {
   var renames = { orderId: 'ti' };
 
   return extend(
@@ -473,7 +473,7 @@ exports.refundedOrder = function(track, settings) {
 };
 
 /**
- * Map Viewed Promotion (Enhanced).
+ * Map Promotion Viewed (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  *
@@ -496,7 +496,7 @@ exports.refundedOrder = function(track, settings) {
  * @return {Object}
  */
 
-exports.viewedPromotion = function(track, settings) {
+exports.promotionViewed = function(track, settings) {
   var renames = {
     creative: 'promo1cr',
     id: 'promo1id',
@@ -514,7 +514,7 @@ exports.viewedPromotion = function(track, settings) {
 };
 
 /**
- * Map Clicked Promotion (Enhanced).
+ * Map Promotion Clicked (Enhanced).
  *
  * https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#enhancedecom
  *
@@ -538,7 +538,7 @@ exports.viewedPromotion = function(track, settings) {
  * @return {Object}
  */
 
-exports.clickedPromotion = function(track, settings) {
+exports.promotionClicked = function(track, settings) {
   var renames = {
     creative: 'promo1cr',
     id: 'promo1id',

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "batch": "^0.5.1",
     "is": "^2.1.0",
     "obj-case": "^0.1.1",
-    "segmentio-facade": "^2.1.0",
-    "segmentio-integration": "^3.2.0",
+    "segmentio-facade": "^3.0.3",
+    "segmentio-integration": "^4.0.0",
     "string-hash": "^1.1.0",
     "unix-time": "^1.0.1"
   },
@@ -35,7 +35,7 @@
     "mocha": "2.x",
     "ms": "0.x",
     "obj-case": "^0.1.1",
-    "segmentio-integration-tester": "^1.1.0",
+    "segmentio-integration-tester": "^2.0.1",
     "superagent": "^1.8.1",
     "uid": "0.0.2"
   }

--- a/test/fixtures/added-product-basic.json
+++ b/test/fixtures/added-product-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Added Product",
+    "event": "Product Added",
     "context": {
       "page": {
         "path": "/integrations",
@@ -25,7 +25,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Added Product",
+    "ea": "Product Added",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pr1ca": "Games",

--- a/test/fixtures/clicked-product-basic.json
+++ b/test/fixtures/clicked-product-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Clicked Product",
+    "event": "Product Clicked",
     "context": {
       "page": {
         "path": "/integrations",
@@ -25,7 +25,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Clicked Product",
+    "ea": "Product Clicked",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pr1ca": "Games",

--- a/test/fixtures/clicked-promotion-basic.json
+++ b/test/fixtures/clicked-promotion-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Clicked Promotion",
+    "event": "Promotion Clicked",
     "properties": {
       "creative": "Some dummy creative here",
       "currency": "USD",
@@ -14,7 +14,7 @@
   },
   "output": {
     "cid": 2710159508,
-    "ea": "Clicked Promotion",
+    "ea": "Promotion Clicked",
     "ec": "EnhancedEcommerce",
     "el": "Some Label",
     "promo1cr": "Some dummy creative here",

--- a/test/fixtures/completed-checkout-step-basic.json
+++ b/test/fixtures/completed-checkout-step-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Completed Checkout Step",
+    "event": "Checkout Step Completed",
     "properties": {
       "option": "FedEx",
       "step": 3
@@ -12,7 +12,7 @@
     "cid": 2710159508,
     "col": "FedEx",
     "cos": 3,
-    "ea": "Completed Checkout Step",
+    "ea": "Checkout Step Completed",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pa": "checkout_option",

--- a/test/fixtures/completed-order-app.json
+++ b/test/fixtures/completed-order-app.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "orderId": "order-id",
       "affiliation": "affiliation",
@@ -38,7 +38,7 @@
       "av": "1.1",
       "t": "event",
       "tid": "UA-27033709-11",
-      "ea": "Completed Order",
+      "ea": "Order Completed",
       "ec": "All",
       "el": "event",
       "ev": 1000,

--- a/test/fixtures/completed-order-basic.json
+++ b/test/fixtures/completed-order-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "orderId": "order-id",
       "affiliation": "affiliation",
@@ -30,7 +30,7 @@
       "cid": 2710159508,
       "t": "event",
       "tid": "UA-27033709-11",
-      "ea": "Completed Order",
+      "ea": "Order Completed",
       "ec": "All",
       "el": "event",
       "ev": 1000,

--- a/test/fixtures/completed-order-cm-cd.json
+++ b/test/fixtures/completed-order-cm-cd.json
@@ -11,7 +11,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "orderId": "order-id",
       "affiliation": "affiliation",
@@ -46,7 +46,7 @@
       "cid": 2710159508,
       "t": "event",
       "tid": "UA-27033709-11",
-      "ea": "Completed Order",
+      "ea": "Order Completed",
       "ec": "All",
       "el": "event",
       "ev": 1000,

--- a/test/fixtures/completed-order-enhanced.json
+++ b/test/fixtures/completed-order-enhanced.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "orderId": "order-id",
       "affiliation": "affiliation",
@@ -29,7 +29,7 @@
     "cid": 2710159508,
     "t": "event",
     "tid": "UA-27033709-11",
-    "ea": "Completed Order",
+    "ea": "Order Completed",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "v": 1,

--- a/test/fixtures/refunded-order-basic.json
+++ b/test/fixtures/refunded-order-basic.json
@@ -2,14 +2,14 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Refunded Order",
+    "event": "Order Refunded",
     "properties": {
       "orderId": 12345
     }
   },
   "output": {
     "cid": 2710159508,
-    "ea": "Refunded Order",
+    "ea": "Order Refunded",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "ni": 1,

--- a/test/fixtures/removed-product-basic.json
+++ b/test/fixtures/removed-product-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Removed Product",
+    "event": "Product Removed",
     "context": {
       "page": {
         "path": "/integrations",
@@ -25,7 +25,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Removed Product",
+    "ea": "Product Removed",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pr1ca": "Games",

--- a/test/fixtures/started-order-basic.json
+++ b/test/fixtures/started-order-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Started Order",
+    "event": "Order Started",
     "context": {
       "page": {
         "path": "/integrations",
@@ -26,7 +26,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Started Order",
+    "ea": "Order Started",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pa": "checkout",

--- a/test/fixtures/updated-order-basic.json
+++ b/test/fixtures/updated-order-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Updated Order",
+    "event": "Order Updated",
     "context": {
       "page": {
         "path": "/integrations",
@@ -26,7 +26,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Updated Order",
+    "ea": "Order Updated",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pa": "checkout",

--- a/test/fixtures/viewed-checkout-step-basic.json
+++ b/test/fixtures/viewed-checkout-step-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Viewed Checkout Step",
+    "event": "Checkout Step Viewed",
     "context": {
       "page": {
         "path": "/integrations",
@@ -37,7 +37,7 @@
     }
   },
   "output": {
-    "ea": "Viewed Checkout Step",
+    "ea": "Checkout Step Viewed",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "cid": 2710159508,
@@ -46,7 +46,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Viewed Checkout Step",
+    "ea": "Checkout Step Viewed",
     "ec": "EnhancedEcommerce",
     "pa": "checkout",
     "pr1br": "Nike",

--- a/test/fixtures/viewed-product-basic.json
+++ b/test/fixtures/viewed-product-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Viewed Product",
+    "event": "Product Viewed",
     "context": {
       "page": {
         "path": "/integrations",
@@ -25,7 +25,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Viewed Product",
+    "ea": "Product Viewed",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pr1ca": "Games",

--- a/test/fixtures/viewed-promotion-basic.json
+++ b/test/fixtures/viewed-promotion-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Viewed Promotion",
+    "event": "Promotion Viewed",
     "context": {
       "page": {
         "path": "/integrations",
@@ -22,7 +22,7 @@
   },
   "output": {
     "cid": 2710159508,
-    "ea": "Viewed Promotion",
+    "ea": "Promotion Viewed",
     "ec": "EnhancedEcommerce",
     "el": "Some Label",
     "dh": "segment.com",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -25,7 +25,7 @@ exports.transaction = function(options) {
     userId: firstId,
     channel: 'server',
     timestamp: new Date(),
-    event: 'Completed Order',
+    event: 'Order Completed',
     properties: {
       orderId: 't-39a224df',
       total: 99.99,


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

There are some Order Completed tests that aren't passing for revenue matching reasons that will need to be fixed.