### PR TITLE
added screenName option to track events

### DIFF
--- a/lib/universal/mapper.js
+++ b/lib/universal/mapper.js
@@ -14,6 +14,7 @@ var lookup = require('obj-case');
 var parse = require('url').parse;
 var pick = require('@ndhoule/pick');
 var values = require('@ndhoule/values');
+var find = require('obj-case');
 
 /**
  * Map Page.
@@ -68,11 +69,13 @@ exports.screen = function(screen, settings) {
 exports.track = function(track, settings) {
   var ni = track.proxy('properties.nonInteraction') || settings.nonInteraction;
   var result = createPageDataForm(track, createCommonGAForm(track, settings));
+  var screenName = find(track.options('Google Analytics'), 'screenName')
   result.ev = Math.round(track.value() || track.revenue() || 0);
   result.el = track.proxy('properties.label') || 'event';
   result.ec = track.category() || 'All';
   result.ea = track.event();
   result.t = 'event';
+  if(screenName) result.cd = screenName;
   if (ni) result.ni = 1;
 
   return result;

--- a/lib/universal/mapper.js
+++ b/lib/universal/mapper.js
@@ -69,13 +69,11 @@ exports.screen = function(screen, settings) {
 exports.track = function(track, settings) {
   var ni = track.proxy('properties.nonInteraction') || settings.nonInteraction;
   var result = createPageDataForm(track, createCommonGAForm(track, settings));
-  var screenName = find(track.options('Google Analytics'), 'screenName')
   result.ev = Math.round(track.value() || track.revenue() || 0);
   result.el = track.proxy('properties.label') || 'event';
   result.ec = track.category() || 'All';
   result.ea = track.event();
   result.t = 'event';
-  if(screenName) result.cd = screenName;
   if (ni) result.ni = 1;
 
   return result;
@@ -603,6 +601,7 @@ function createCommonGAForm(facade, settings) {
   if (campaign.source) form.cs = campaign.source;
   if (campaign.medium) form.cm = campaign.medium;
   if (campaign.content) form.cc = campaign.content;
+  if (screen.name) form.cd = screen.name;
 
   // screen
   if (screen.height && screen.width) {

--- a/test/fixtures/track-screen-name.json
+++ b/test/fixtures/track-screen-name.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "some-event",
+    "properties": {
+      "value": 1,
+      "label": "some-label",
+      "category": "some-category",
+      "nonInteraction": 1
+    },
+    "integrations": {
+      "Google Analytics": {
+        "screenName": "Home"
+      }
+    }
+  },
+  "output": {
+    "tid": "UA-27033709-11",
+    "cid": 2710159508,
+    "ea": "some-event",
+    "ec": "some-category",
+    "el": "some-label",
+    "ev": 1,
+    "t": "event",
+    "ni": 1,
+    "cd": "Home",
+    "v": 1
+  }
+}

--- a/test/fixtures/track-screen-name.json
+++ b/test/fixtures/track-screen-name.json
@@ -9,9 +9,9 @@
       "category": "some-category",
       "nonInteraction": 1
     },
-    "integrations": {
-      "Google Analytics": {
-        "screenName": "Home"
+    "context": {
+      "screen": {
+        "name": "Home"
       }
     }
   },

--- a/test/universal.js
+++ b/test/universal.js
@@ -180,7 +180,7 @@ describe('Google Analytics :: Universal', function() {
         .expects(200, done);
     });
 
-    it('should pass screenName to GA from options.screenName', function(done) {
+    it('should pass screenName to GA from context.screen.name', function(done) {
       var json = test.fixture('track-screen-name');
       test
         .set(settings)

--- a/test/universal.js
+++ b/test/universal.js
@@ -180,6 +180,15 @@ describe('Google Analytics :: Universal', function() {
         .expects(200, done);
     });
 
+    it('should pass screenName to GA from options.screenName', function(done) {
+      var json = test.fixture('track-screen-name');
+      test
+        .set(settings)
+        .track(json.input)
+        .sendsAlmost(json.output, {ignored: ['qt']})
+        .expects(200, done);
+    })
+
     it('should fallback to .revenue after .value', function(done) {
       var json = test.fixture('track-revenue');
       test


### PR DESCRIPTION
Added a screenName option for GA track calls - to mimic this native GA functionality:
ga('send', 'Videos', 'play', 'Fall Campaign', {screenName: 'Home'});


