### PR TITLE
fix order completed route for regular ecommerce

### DIFF
--- a/lib/universal/index.js
+++ b/lib/universal/index.js
@@ -59,8 +59,8 @@ GA.prototype.track = function(track, callback) {
  * @param {Function} callback
  */
 
-GA.prototype.completedOrder = function(track, fn) {
-  var payloads = mapper.completedOrder(track, this.settings);
+GA.prototype.orderCompleted = function(track, fn) {
+  var payloads = mapper.orderCompleted(track, this.settings);
   var batch = new Batch();
   var self = this;
 


### PR DESCRIPTION
Update routes for completed Order event to match new ecommerce spec. This should fix ecommerce reporting for anyone using universal analytics and not using enhanced ecommerce.