### PR TITLE
added partial refund functionality

### DIFF
--- a/lib/universal/mapper.js
+++ b/lib/universal/mapper.js
@@ -467,6 +467,7 @@ exports.orderRefunded = function(track, settings) {
   return extend(
     formatEnhancedEcommerceEvent(track, 'refund'),
     createCommonGAForm(track, settings),
+    formatProducts(track.products()),
     pick(values(renames), track.properties(renames)),
     { ni: 1 }
   );

--- a/test/fixtures/refunded-order-partial.json
+++ b/test/fixtures/refunded-order-partial.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "userId": "user-id",
+    "type": "track",
+    "event": "Order Refunded",
+    "properties": {
+      "orderId": 12345,
+      "products": [
+        {
+          "product_id": 111,
+          "quantity": 2
+        }
+      ]
+    }
+  },
+  "output": {
+    "cid": 2710159508,
+    "ea": "Order Refunded",
+    "ec": "EnhancedEcommerce",
+    "el": "event",
+    "ni": 1,
+    "pa": "refund",
+    "pr1id": 111,
+    "pr1qt": 2,
+    "t": "event",
+    "ti": 12345,
+    "tid": "UA-27033709-11",
+    "v": 1
+  }
+}

--- a/test/universal.js
+++ b/test/universal.js
@@ -449,6 +449,17 @@ describe('Google Analytics :: Universal', function() {
       });
     });
 
+    describe('#refundedOrderPartial', function() {
+      it('should send the right data', function(done) {
+        var json = test.fixture('refunded-order-partial');
+        test
+          .set(settings)
+          .track(json.input)
+          .sendsAlmost(json.output, {ignored: ['qt']})
+          .expects(200, done);
+      });
+    });
+
     describe('#clickedPromotion', function() {
       it('should send the right data', function(done) {
         var json = test.fixture('clicked-promotion-basic');
@@ -602,6 +613,19 @@ describe('Google Analytics :: Universal', function() {
     describe('#refundedOrder', function() {
       it('should be a valid hit', function(done) {
         var json = test.fixture('refunded-order-basic');
+        test.integration.endpoint = 'https://ssl.google-analytics.com/debug/collect';
+        test.integration.request = requestOverride;
+        test
+          .set(settings)
+          .track(json.input)
+          .sends(json.output)
+          .expects(/"valid": true/, done);
+      });
+    });
+
+    describe('#refundedOrderPartial', function() {
+      it('should be a valid hit', function(done) {
+        var json = test.fixture('refunded-order-partial');
         test.integration.endpoint = 'https://ssl.google-analytics.com/debug/collect';
         test.integration.request = requestOverride;
         test


### PR DESCRIPTION
This PR adds partial refund functionality to our server-side GA integration. Currently, customers can only do full refunds with our server-side GA integration. Partial refunds are not Spec'd yet - but this fix follows the traditional patterns of our ecommerce spec, and is likely to fall within Spec when (if) we do add partial refunds to the spec. In the interim, this works as a nice, non-breaking, partial refund feature - requested by Motley Fool - and it mimics the pattern already in place in our A.js GA integration.