### PR TITLE
deprecate order started, use checkout started

### DIFF
--- a/lib/universal/enhanced-ecommerce.js
+++ b/lib/universal/enhanced-ecommerce.js
@@ -67,17 +67,17 @@ exports.productRemoved = function(track, done) {
 };
 
 /**
- * Order Started. (Enhanced ecommerce.)
+ * Checkout Started (Enhanced ecommerce.)
  *
  * @param {Track} track
  * @param {Function} done
  */
 
-exports.orderStarted = function(track, done) {
+exports.checkoutStarted = function(track, done) {
   this
     .post()
     .type('form')
-    .send(mapper.orderStarted(track, this.settings))
+    .send(mapper.checkoutStarted(track, this.settings))
     .end(this.handle(done));
 };
 

--- a/lib/universal/mapper.js
+++ b/lib/universal/mapper.js
@@ -263,7 +263,7 @@ exports.productRemoved = function(track, settings) {
  * @return {Object}
  */
 
-exports.orderStarted = function(track, settings) {
+exports.checkoutStarted = function(track, settings) {
   return exports.checkoutStepViewed(track, settings);
 };
 

--- a/test/fixtures/started-checkout-basic.json
+++ b/test/fixtures/started-checkout-basic.json
@@ -2,7 +2,7 @@
   "input": {
     "userId": "user-id",
     "type": "track",
-    "event": "Order Started",
+    "event": "Checkout Started",
     "context": {
       "page": {
         "path": "/integrations",
@@ -26,7 +26,7 @@
     "dh": "segment.com",
     "dp": "/integrations",
     "dt": "Integrations - Segment",
-    "ea": "Order Started",
+    "ea": "Checkout Started",
     "ec": "EnhancedEcommerce",
     "el": "event",
     "pa": "checkout",

--- a/test/universal.js
+++ b/test/universal.js
@@ -394,9 +394,9 @@ describe('Google Analytics :: Universal', function() {
       });
     });
 
-    describe('#startedOrder', function() {
+    describe('#startedCheckout', function() {
       it('should send the right data', function(done) {
-        var json = test.fixture('started-order-basic');
+        var json = test.fixture('started-checkout-basic');
         test
           .set(settings)
           .track(json.input)
@@ -545,9 +545,9 @@ describe('Google Analytics :: Universal', function() {
       });
     });
 
-    describe('#startedOrder', function() {
+    describe('#startedCheckout', function() {
       it('should be a valid hit', function(done) {
-        var json = test.fixture('started-order-basic');
+        var json = test.fixture('started-checkout-basic');
         test.integration.endpoint = 'https://ssl.google-analytics.com/debug/collect';
         test.integration.request = requestOverride;
         test


### PR DESCRIPTION
This is coupled with https://github.com/segmentio/analytics-events/pull/7

@f2prateek updating `order started` to `checkout started`