### PR TITLE
bump work_version to enable simulator

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,11 @@
 machine:
   node:
-    version: 0.10.38
+    version: 6.9.2 
   services:
     - docker
     - redis
+  environment:
+    WORKER_VERSION: 3.x
 
 dependencies:
   pre:


### PR DESCRIPTION
I'm not sure if the goal is to change each integration to use 3.x of the worker eventually. This change enables the publishing to the simulator channel.

App PR: https://github.com/segmentio/app/pull/3058

cc @segment-integrations/core